### PR TITLE
Add clarity around uncommenting code

### DIFF
--- a/getting_started/step_by_step/scripting_player_input.rst
+++ b/getting_started/step_by_step/scripting_player_input.rst
@@ -104,7 +104,7 @@ Moving when pressing "up"
 -------------------------
 
 To only move when pressing a key, we need to modify the code that calculates the
-velocity. Uncomment the code and replace the line starting with ``var velocity`` with the code below.
+velocity. Uncomment the code *(that you just commented)* and replace the line starting with ``var velocity`` with the code below.
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
The commenting out of the position isn't obviously restored by the code snippets, so drawing a little extra attention to it in the descriptive text seems advisable as there's a reasonable chance that it won't be noticed right away and the "student" will be initially confused that they're sprite doesn't move forward.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
